### PR TITLE
Navcoin release dockers

### DIFF
--- a/releases/navcoin-4-2-0/Dockerfile
+++ b/releases/navcoin-4-2-0/Dockerfile
@@ -2,25 +2,31 @@ FROM ubuntu:16.04
 
 LABEL maintainer.0="Paul Sanderson"
 
+#NavCoin settings
 ARG NAVCOIN_VERSION=4.2.0
 ARG NAV_CHK=166d64c4e61a2ff0900ce89bdf7e8b58b2ca97577af737c4b0b69f917d51208c
 ARG NAV_PKG=navcoin-${NAVCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 
+#install the libs needed
 RUN apt-get update -y
 RUN apt-get install wget -y
 RUN apt-get install libcurl4-openssl-dev -y
 
-
 WORKDIR /tmp
 
+#download NavCoin and check it
 RUN mkdir -p ${NAVCOIN_VERSION}
 RUN wget "https://github.com/NAVCoin/navcoin-core/releases/download/${NAVCOIN_VERSION}/${NAV_PKG}"
 RUN echo "${NAV_CHK}  ${NAV_PKG}" | sha256sum -c
 RUN tar -xzf ${NAV_PKG}
 
+# move navcoind
 WORKDIR /tmp/navcoin-${NAVCOIN_VERSION}/bin
 RUN cp navcoind /bin/navcoind
 
 WORKDIR /
+
+#cleanup
+RUN rm -rf /tmp/*
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/releases/navcoin-4-2-0/Dockerfile
+++ b/releases/navcoin-4-2-0/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+LABEL maintainer.0="Paul Sanderson"
+
+ARG NAVCOIN_VERSION=4.2.0
+ARG NAV_CHK=166d64c4e61a2ff0900ce89bdf7e8b58b2ca97577af737c4b0b69f917d51208c
+ARG NAV_PKG=navcoin-${NAVCOIN_VERSION}-x86_64-linux-gnu.tar.gz
+
+RUN apt-get update -y
+RUN apt-get install wget -y
+RUN apt-get install libcurl4-openssl-dev -y
+
+
+WORKDIR /tmp
+
+RUN mkdir -p ${NAVCOIN_VERSION}
+RUN wget "https://github.com/NAVCoin/navcoin-core/releases/download/${NAVCOIN_VERSION}/${NAV_PKG}"
+RUN echo "${NAV_CHK}  ${NAV_PKG}" | sha256sum -c
+RUN tar -xzf ${NAV_PKG}
+
+WORKDIR /tmp/navcoin-${NAVCOIN_VERSION}/bin
+RUN cp navcoind /bin/navcoind
+
+WORKDIR /
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/releases/navcoin-4-2-0/docker-compose.yml
+++ b/releases/navcoin-4-2-0/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  navcoin-4-2-1:
+  navcoin-4-2-0:
     build:
         context: .
     ports:

--- a/releases/navcoin-4-2-0/docker-compose.yml
+++ b/releases/navcoin-4-2-0/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  navcoin-4-2-1:
+    build:
+        context: .
+    ports:
+      - 44440:44440
+      - 44444:44444
+      - 44445:44445
+    expose:
+      - "44440"
+      - "44444"
+      - "44445"
+    command:
+      - "navcoind -rpcuser=user -rpcpassword=rpcpassword -rpcallowip=0.0.0.0/0 -ntpminmeasures=0"

--- a/releases/navcoin-4-2-1/Dockerfile
+++ b/releases/navcoin-4-2-1/Dockerfile
@@ -2,25 +2,31 @@ FROM ubuntu:16.04
 
 LABEL maintainer.0="Paul Sanderson"
 
+#NavCoin settings
 ARG NAVCOIN_VERSION=4.2.1
 ARG NAV_CHK=1500674cc0c9f31a5369c21dd59b3cccdbf25c5db8a04f728967029552725d3e
 ARG NAV_PKG=navcoin-${NAVCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 
+#install the libs needed
 RUN apt-get update -y
 RUN apt-get install wget -y
 RUN apt-get install libcurl4-openssl-dev -y
 
-
 WORKDIR /tmp
 
+#download NavCoin and check it
 RUN mkdir -p ${NAVCOIN_VERSION}
 RUN wget "https://github.com/NAVCoin/navcoin-core/releases/download/${NAVCOIN_VERSION}/${NAV_PKG}"
 RUN echo "${NAV_CHK}  ${NAV_PKG}" | sha256sum -c
 RUN tar -xzf ${NAV_PKG}
 
+# move navcoind
 WORKDIR /tmp/navcoin-${NAVCOIN_VERSION}/bin
 RUN cp navcoind /bin/navcoind
 
 WORKDIR /
+
+#cleanup
+RUN rm -rf /tmp/*
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/releases/navcoin-4-2-1/Dockerfile
+++ b/releases/navcoin-4-2-1/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+LABEL maintainer.0="Paul Sanderson"
+
+ARG NAVCOIN_VERSION=4.2.1
+ARG NAV_CHK=1500674cc0c9f31a5369c21dd59b3cccdbf25c5db8a04f728967029552725d3e
+ARG NAV_PKG=navcoin-${NAVCOIN_VERSION}-x86_64-linux-gnu.tar.gz
+
+RUN apt-get update -y
+RUN apt-get install wget -y
+RUN apt-get install libcurl4-openssl-dev -y
+
+
+WORKDIR /tmp
+
+RUN mkdir -p ${NAVCOIN_VERSION}
+RUN wget "https://github.com/NAVCoin/navcoin-core/releases/download/${NAVCOIN_VERSION}/${NAV_PKG}"
+RUN echo "${NAV_CHK}  ${NAV_PKG}" | sha256sum -c
+RUN tar -xzf ${NAV_PKG}
+
+WORKDIR /tmp/navcoin-${NAVCOIN_VERSION}/bin
+RUN cp navcoind /bin/navcoind
+
+WORKDIR /
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/releases/navcoin-4-2-1/docker-compose.yml
+++ b/releases/navcoin-4-2-1/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   navcoin-4-2-1:
     build:
-        context: ..
+        context: .
     ports:
       - 44440:44440
       - 44444:44444
@@ -13,4 +13,4 @@ services:
       - "44444"
       - "44445"
     command:
-      - "navcoind -rpcuser=user -rpcpassword=rpcpassword -rpcallowip=0.0.0.0/0"
+      - "navcoind -rpcuser=user -rpcpassword=rpcpassword -rpcallowip=0.0.0.0/0 -ntpminmeasures=0"

--- a/releases/navcoin-4-2-1/docker-compose.yml
+++ b/releases/navcoin-4-2-1/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  navcoin-4-2-1:
+    build:
+        context: ..
+    ports:
+      - 44440:44440
+      - 44444:44444
+      - 44445:44445
+    expose:
+      - "44440"
+      - "44444"
+      - "44445"
+    command:
+      - "navcoind -rpcuser=user -rpcpassword=rpcpassword -rpcallowip=0.0.0.0/0"


### PR DESCRIPTION
Creates a new set of docker images that run the release versions. These can be used for dev, production systems and people who want to run the daemon. 

This uses the compile binaries from GitHub releases. The binary files are checksum checked but for ultimate peace of mind, you should compile from the source.

The Image for this container is 269MB, a vast improvement over the dev-docker build.

I have made a releases folder which holds the docker files for each release.  


